### PR TITLE
Adds the comprehensive rules and starter guide

### DIFF
--- a/TGC Comprehensive Rules.md
+++ b/TGC Comprehensive Rules.md
@@ -3,8 +3,7 @@
 <h2> 0: About this Document </h2> <br>
 
 0.1: This is the TGC Comprehensive Rules, explaining how to play the TGC. <br>
-0.2: Any deviations between this document, other documents and/or the Wiki then this document\'s wording is the ruling one.<br>
-    0.2.1: An exception is given to the rulings document, which can overrule these rules when talking about specific cards. <br>
+0.2: Card text takes priority over the rules, and specific interactions mentioned in this repository take priority over the general rules.<br>
 0.3: Sections marked as ".x:" are clarifications; they are not necessary rules text but examples, reminders and etc to make learning the game easier. <br>
     0.3.1: Sections ".x:" also fall under rule 0.2 in that if there were to be deviations or contradictions between the ".x:" sections and the main sections of this document then the non-".x:" sections take precedence over the ".x:" ones. <br>
 

--- a/TGC Comprehensive Rules.md
+++ b/TGC Comprehensive Rules.md
@@ -28,7 +28,6 @@
 1.5: Then, each player may mulligan cards in their hand. <br>
     1.5.1 During the mulligan each player may discard a card (face-down) from their hand to draw 1. This may be done upto three times, and you do not need to draw all three at once.<br>
         1.5.1.x: The opponent is not allowed to see the discarded cards but can know how many cards you chose to discard.  <br>
-    1.5.2: They can perform this up to 3 times. <br>
     1.5.3: After both players have finished mulliganing shuffle all discarded cards back into the deck. <br>
 
 1.6: Both players starts with 20 Heathshards (or HS) and 1 Plasma. <br>

--- a/TGC Comprehensive Rules.md
+++ b/TGC Comprehensive Rules.md
@@ -45,7 +45,7 @@
 
 1.10: During the Draw Phase a number of automatic game actions happen, in the following order. <br>
     1.10.1: The turn player\'s plasma gets set to the amount of Draw Phases they have had in total, including this one. <br>
-        1.10.1.x: So on their first turn they get 1 mana, on their second 2 mana, on their third 3 mana, etc. <br>
+        1.10.1.x: So on their first turn they get 1 plasma, on their second 2 plasma, on their third 3 plasma, etc. <br>
     1.10.2: The turn player draws a card. <br>
     1.10.3: The turn player untaps all their tapped cards. <br>
     1.10.4: The "Pass Phase" action is immediately performed. <br>

--- a/TGC Comprehensive Rules.md
+++ b/TGC Comprehensive Rules.md
@@ -44,7 +44,7 @@
         1.9.x: There is no \"Play Phase 2\". You do not get to return to a Play Phase after the Battle Phase. <br>
 
 1.10: During the Draw Phase a number of automatic game actions happen, in the following order. <br>
-    1.10.1: The turn player\'s mana gets set to the amount of Draw Phases they have had in total, including this one. <br>
+    1.10.1: The turn player\'s plasma gets set to the amount of Draw Phases they have had in total, including this one. <br>
         1.10.1.x: So on their first turn they get 1 mana, on their second 2 mana, on their third 3 mana, etc. <br>
     1.10.2: The turn player draws a card. <br>
     1.10.3: The turn player untaps all their tapped cards. <br>

--- a/TGC Comprehensive Rules.md
+++ b/TGC Comprehensive Rules.md
@@ -26,7 +26,7 @@
 
 1.4: Each player draws 5 cards from their deck. <br>
 1.5: Then, each player may mulligan cards in their hand. <br>
-    1.5.1 During the mulligan each player may discard a card (face-down) from their hand to draw 1. <br>
+    1.5.1 During the mulligan each player may discard a card (face-down) from their hand to draw 1. This may be done upto three times, and you do not need to draw all three at once.<br>
         1.5.1.x: The opponent is not allowed to see the discarded cards but can know how many cards you chose to discard.  <br>
     1.5.2: They can perform this up to 3 times. <br>
     1.5.3: After both players have finished mulliganing shuffle all discarded cards back into the deck. <br>

--- a/TGC Comprehensive Rules.md
+++ b/TGC Comprehensive Rules.md
@@ -1,0 +1,183 @@
+<h1> Comprehensive TGC Rules </h1>
+
+<h2> 0: About this Document </h2> <br>
+
+0.1: This is the TGC Comprehensive Rules, explaining how to play the TGC. <br>
+0.2: Any deviations between this document, other documents and/or the Wiki then this document\'s wording is the ruling one.<br>
+    0.2.1: An exception is given to the rulings document, which can overrule these rules when talking about specific cards. <br>
+0.3: Sections marked as ".x:" are clarifications; they are not necessary rules text but examples, reminders and etc to make learning the game easier. <br>
+    0.3.1: Sections ".x:" also fall under rule 0.2 in that if there were to be deviations or contradictions between the ".x:" sections and the main sections of this document then the non-".x:" sections take precedence over the ".x:" ones. <br>
+
+<h2> 1: Card & Game Basics </h2> 
+
+1.1: To start a game you need two players. <br>
+
+1.2: Each player needs a deck of cards to play. <br>
+    1.2.1: Decks must include 40 total cards.  <br>
+    1.2.2: You can run up to 4 copies of a specific card in your deck. <br>
+    1.2.3: All cards in your deck must be a legal TGC card. <br>
+    1.2.4: The following rules are deckbuilding rules for the tournament standard of TGC and may be ignored freely in casual play. <br>
+        1.2.4.1: When building your deck choose 3 card subtypes. Every card in your deck must have at least one of these subtypes. <br>
+        1.2.4.2: Every card in your deck must be legal, not banned and not be misprint. <br>
+
+1.3: A coin toss is done to decide who goes first. <br>
+    1.3.1: The coin toss decides who goes first, not who decides to go first. <br>
+    1.3.x: This means a player is decided to be heads and the other tails; whichever side the coin lands on goes first. <br>
+
+1.4: Each player draws 5 cards from their deck. <br>
+1.5: Then, each player may mulligan cards in their hand. <br>
+    1.5.1 During the mulligan each player may discard a card (face-down) from their hand to draw 1. <br>
+        1.5.1.x: The opponent is not allowed to see the discarded cards but can know how many cards you chose to discard.  <br>
+    1.5.2: They can perform this up to 3 times. <br>
+    1.5.3: After both players have finished mulliganing shuffle all discarded cards back into the deck. <br>
+
+1.6: Both players starts with 20 Heathshards (or HS) and 1 Plasma. <br>
+1.7: The game begins on the Draw Phase of the player who won the coin toss. <br>
+1.8: The player that plays second keeps the coin and places it besides them, flipped on heads. <br>
+     1.9.x: This is relevant for the \"Flip Coin\" action, detailed in 3.6 <br>
+
+1.9: Turns in this game are divided in 5 parts, called the phases. <br>
+    1.9.a: Draw Phase <br>
+    1.9.b: Standby Phase <br>
+    1.9.c: Play Phase <br>
+    1.9.d: Battle Phase <br>
+    1.9.e: End Phase <br>
+        1.9.x: There is no \"Play Phase 2\". You do not get to return to a Play Phase after the Battle Phase. <br>
+
+1.10: During the Draw Phase a number of automatic game actions happen, in the following order. <br>
+    1.10.1: The turn player\'s mana gets set to the amount of Draw Phases they have had in total, including this one. <br>
+        1.10.1.x: So on their first turn they get 1 mana, on their second 2 mana, on their third 3 mana, etc. <br>
+    1.10.2: The turn player draws a card. <br>
+    1.10.3: The turn player untaps all their tapped cards. <br>
+    1.10.4: The "Pass Phase" action is immediately performed. <br>
+    1.10.5: This Pass Phase does not create an Open gamestate. <br>
+
+1.11: Terminology definitions: <br>
+    1.11.a: When you draw a card you add the top card of your deck to your hand. <br>
+    1.11.b: When a card is destroyed it is moved to the discard pile <br>
+        1.11.b.1: When a card is destroyed all cards attached to it also get destroyed. <br>
+    1.11.c: When a card is tapped it is flipped sideways. <br>
+    1.11.d: When a card is untapped it is returned to the upright position <br>
+
+1.12: Any player that have their HP reduced to, set to or at 0 loses the game automatically. <br>
+1.12.1: When this happens the other player immediately wins the game. <br>
+    1.12.x: This can happen even if the game is in a Closed Gamestate <br>
+
+<h2> Open and Closed States </h2>  <br>
+
+2: The gamestate can either be Open or Closed. <br>
+
+2.1: In a Closed gamestate no players may take any actions with the sole exception of: <br>
+    2.1.a: Surrendering <br>
+    2.1.b: When resolving an activated Effect that, as a part of its effect, allows its user to make a choice <br>
+
+2.2: In an Open gamestate then one of the players may take actions, depending on the type of Open gamestate, the phase and game information. <br>
+
+2.3: There are three types of Open gamestates: Open Play Gamestate, Open Battle Gamestate and the Open Quick Gamestate <br>
+    2.3.x: These can be refered to as Open Play, Open Battle and Open Quick. <br>
+
+2.4: During the gamestates the turn player may perform actions based on the gamestate. <br>
+    2.4.1: During the Open Play gamestate you can: <br>
+        2.4.1.a: Play A Card <br>
+            2.4.1.a.x: This can be any type of card. <br>
+        2.4.1.b: Activate An Effect    <br>
+        2.4.1.c: Pass Phase <br>
+        2.4.1.d: Flip Coin <br>
+    2.4.2: During the Battle Play gamestate you can: <br>
+        2.4.2.a: Play A Card <br>
+            X.4.2.a.x: This must be an Instant card. <br>
+        2.4.2.b: Activate An Effect <br>
+            X.4.2.b.a: This must be a Quick effect or one that specifically can or must do so in the Battle Phase. <br>
+        2.4.2.c: Pass Phase <br>
+        2.4.2.d: Declare Battle <br>
+    2.4.3: During the Quick Play gamestate you can: <br>
+        2.4.3.a: Play A Card <br>
+            2.4.2.a.x: This must be an Instant card. <br>
+        2.4.3.b: Activate An Effect <br>
+            2.4.2.b.1: This must be a Quick effect. <br>
+        2.4.3.c: Do Nothing <br>
+
+2.5: Different phases have diferente gamestates they default to. <br>
+    2.5.1: The only exception is the Draw Phase which does not have any Open gamestates and **always** is Closed. No Open Quick gamestate may happen here. <br>
+    2.5.2: When the gamestate "defaults" it means the gamestate is changed from its current gamestate to a new gamestate. Which new gamestate gets made depends on the current phase. <br>
+        2.5.2.x: This is called "defaulting", "the gamestate defaulting" or similar variations. <br>
+    2.3.3: Once a gamestate defaults the player that can play in that gamestate is the turn player. <br>
+        2.3.x: The non turn player can only play effects after the turn player used the "Pass Phase" action. <br>
+    2.5.4: The phases\' default gamestates are: <br>
+        2.5.3.a: Standby Phase - Open Quick Gamestate <br>
+        2.5.3.b: Play Phase - Open Play Gamestate <br>
+        2.5.3.c: Battle Phase - Open Battle Gamestate <br>
+        2.5.3.d: End Phase - Open Quick Gamestate <br>
+
+<h2>  3: Actions to Perform </h2> <br>
+
+3.1: When a player declares an action then it immediately becomes a closed gamestate. <br>
+
+3.2: The following actions are Control Actions that don\'t influence the board but rather the gamestate and/or the phases of the game. <br>
+    3.2.1: Control actions do not close the gamestate unless otherwise stated. <br>
+    3.2.a: "Pass Phase" <br>
+        3.2.a.1: When this action is performed an Open Quick gamestate is opened. The next time it defaults the gamestate becomes Closed and the phase gets changed to the next phase <br>
+        3.2.a.1.x: The sequence of the phases is detailed in 1.9 <br>
+        3.2.a.2: After the phase changes a Open Quick gamestate is opened. <br>
+    3.2.b: \"Do Nothing\" <br>
+        3.2.b.1: When this action is performed then the same type of gamestate that this action was created in gets created but for the opponent instead.<br>
+        3.2.b.2: If this action is done by both players consecutively then the gamestate defaults. <br>
+
+3.3: Play A Card <br>
+    3.3.1: In order to use this action you must have a valid card in your hand you can activate. <br>
+        3.3.1.1: You must have enough plasma to play the card <br>
+        3.3.1.2: There must be at least one valid to equip creature in play in order to play an Equipment card <br>
+    3.3.2: Reduce your plasma count by the cost of the card, then put it on the field. <br>
+    3.3.3: Depending on the type of card you then perform the additional actions: <br>
+        3.3.3.a: Creature Card <br>
+            3.3.3.a.1: The creature comes into play tapped. <br>
+        3.3.3.b: Equipment Card <br>
+            3.3.3.b.1: Select a creature on either side of the field. <br>
+            3.3.3.b.2: Attach the Equipment card underneath the creature card. <br>
+            3.3.3.b.3: The creature gains resolve and power equal to the equipment cards\' resolve and power. <br>
+                3.3.3.b.3.1: If the attached equipment is destroyed or removed then the creature loses these bonus. <br>
+        3.3.3.c: Instant Card and Event Card <br>
+            3.3.3.c.1: The effect of the card is applied and then the card is discarded. <br>
+        3.3.3.d: Battlefield Card <br>
+            3.3.3.d.1: If you already have a Battlefield card on the field the old one is destroyed before the new gets placed on the field. <br>
+    3.3.4: Afterwards a Quick Open gamestate is opened. <br>
+
+3.4: Activate an Effect <br>
+    3.4.1: In order to use this action you must have an effect you can activate. <br>
+        3.4.1.x: This refers to effects that are not specifically playing a card from hand using the mana cost. Tap effects, On Play: effects, discard pile effects, etc all fall under this category. <br>
+    3.4.2: You can only activate an effect that has a specific trigger if that trigger has happened within the last Closed gamestate and now. <br>
+        3.4.2.x: Control actions (such as Pass Priority or Pass Phase) have special rules on if they trigger a Closed gamestate or not, affecting when certain cards can trigger or not. <br>
+    3.4.3: When using a card\'s effect you follow the instructions written on the card itself. <br>
+    3.4.4: Once the effect of the card finishes a Quick Open gamestate is opened. <br>
+
+3.5: Declare Battle <br>
+    3.5.1: When you Declare Battle, select one of your creatures to be the attacker. <br>
+    3.5.2: Then, choose either a direct attack or an attack against a creature and perform that with the selected creature as the attacker. <br>
+        3.5.2.x: The rules for that are in 4.1 and 4.2, respectively. <br>
+
+3.6: Flip Coin <br>
+    3.6.1: This action may only be performed if you have the coin and it\'s on the heads position. <br>
+    3.6.2: When you perform this action, flip the coin to the tails position. Then, you gain +1 plasma for this turn. <br>
+    3.6.2: Afterwards a Quick Open gamestate is opened. <br>
+
+<h2>  4: Card Combat </h2> <br>
+
+4.1: In a direct attack the defending player may choose one of their non-tapped creatures to block with. <br>
+    4.1.1: If the defending player chooses not to defend or does not have units to defend with then the direct attack goes through. <br>
+        4.1.1.1: If the defending player does choose to block then it becomes a creature attack. <br>
+    4.1.2: After the direct attack goes through a Open Quick Gamestate is opened. The next time the gamestate defaults close the gamestate and move to 4.1.3. <br>
+        4.1.2.1: If the attacking creature leaves the field or becomes unable to perform a direct attack before the gamestate defauls then when it defaults it defaults normally rather than proceeding to 4.1.3   <br>
+    4.1.3: When this happens the attacking creature deals damage to the opponent player equal to its power. <br>
+    4.1.4: Afterwards the creature gets tapped and the gamestate defaults. <br>
+
+4.2: In a creature attack two creatures attack eachother. <br>
+    4.2.1: If the creature attack is declared by the opponent in response to a direct attack then they choose the defender <br>
+        4.2.1.1: If the creature attack is declared by the turn player directly then the turn player chooses the defender <br>
+    4.2.2: Afterwards a Open Quick Gamestate is opened. The next time the gamestate defaults close the gamestate and move to 4.2.3. <br>
+        4.2.2.1: If the attacking creature leaves the field or becomes unable to perform this attack before the gamestate defauls then when it defaults it defaults normally rather than proceeding to 4.2.3 <br>
+    4.2.3: Both creatures deal damage equal to their power to eachother <br>
+    4.2.4: After combat any surviving creatures get tapped. The gamestate then defaults. <br>
+
+4.3: Damage is a thing that can be done to creatures or players <br>
+    4.3.1: When a creature or player is to be damaged reduce their HS (for players) or Resolve (for creatures) equal to the amount of damage they're taking <br>
+    4.3.2: If a creature's resolve were to go to 0 or below then it is destroyed. <br>

--- a/TGC Starter Guide.md
+++ b/TGC Starter Guide.md
@@ -1,0 +1,93 @@
+\-\-- Setting up the Game \-\--
+
+To play the game you need: <br>
+-\> Two Players <br>
+-\> Two decks of exactly 40 cards. No more than 4 copies of a single card in the deck. <br>
+-\> A coin <br>
+-\> \[Optional\] A holodeck on the TGC setting <br>
+
+Flip the coin to decide who goes first, then keep the coin next to the
+other player, flipped with heads up. Both players start with 20
+Healthstards (this game\'s HP), with the goal of reducing the
+opponent\'s Healthshards to 0. At the start of each game each player
+draws 5 cards then mulligans. Each player can, up to 3 times, discard a
+card face-down then draw 1. These discarded cards then get shuffled back
+into the deck.
+
+IMPORTANT: When between-rounds persistency for TGC cards get added a new
+deckbuilding rule will be added: You can only have 3 card subtypes on
+your deck. Until persistency gets added (or for draft play) this rule
+can and should be ignored.
+
+\-\-\-\-\-\-- Game Basics \-\-\-\-\--
+
+At the start of every turn you draw 1 card.
+
+At the start of your first turn you gain 1 plasma. At the start of your
+second you gain 2 plasma, of our third 3 plasma, etc. Plasma is used to
+play cards, being spent as you play them. Plasma does carry over from
+your turn into your opponent\'s turn but any unspent plasma is lost by
+the beginning of your turn. If you went second you start with the coin,
+which is put at the table with heads facing up. Once per game you may
+flip the coin from heads to tails to gain +1 plasma that turn.
+
+Your turn is divided into two main phases the Play Phase and the Battle
+Phase.
+
+During the Play Phase you may play cards, activate effects and etc. Once
+you\'re finished with it you move to the Battle Phase. During the Battle
+Phase you use your creature cards to attack the opponents\' creatures on
+their side of the field. Once you finished the Battle Phase you cannot
+go back to your Play Phase - once you start the Battle Phase you can no
+longer play new cards or activate monster effects until the rest of the
+turn, with the exception of Instant cards. Always remember to do
+everything you want to do before starting the Battle Phase!
+
+\-\-\-\-- Card Types \-\-\-\-\--
+
+There are 5 types of cards in the game: Creature, Equipment, Event,
+Instant and Battlefield.
+
+Creature cards stay on the field when you play them. They have a power
+(which is how much damage they do), a resolve (which is how much damage
+they can take before being destroyed) and effect text. You can use them
+for combat and winning the game!
+
+Equipment cards can be equipped to your Creature cards, letting you buff
+them with new powers and better stats. When you use it, put it
+underneath the Creature card you want to equip it to.
+
+Event cards have an effect that applies when they are played. They then
+go to the discard pile after being played.
+
+Instant cards are similar to Events however can be played at any time -
+they can be played on the Play Phase but also the Battle Phase, and even
+on the opponent\'s turn! The main rules of it are that you cannot use an
+Instant card after the opponent activates a card but before it goes in
+effect - if the opponent plays a card that deals 3 damage to one of your
+cards for example you cannot \"respond\" with an Instant to heal it
+before it gets destroyed.
+
+Battlefield are cards that stay on the field after being played but are
+not creatures. Each player can only have one Battlefield card on their
+field at once.
+
+\-\-\-\-- Card Combat \-\-\-\--
+
+You can only attack with untapped units. In the Battle Phase you can
+perform two types of attacks: direct attacks and enemy attacks.
+
+When you declare a direct attack the opponent can either choose to let
+it go through and take damage equal to the power of the attacking card
+or block it. When they block it they choose one of their untapped units
+and they fight. If the opponent has no untapped units then they can\'t
+block.
+
+You can also make your creatures to attack one of the opponent\'s
+creatures. In that case you choose which of the enemy\'s units becomes
+the blocker.
+
+When two creatures battle they both take damage equal to the other
+creature\'s power. This can mean that both creatures get destroyed in an
+attack. After an attack, every creature gets tapped, both the attacker
+and the defender.


### PR DESCRIPTION
We need files in here! (the rest of this PR is mirrored from https://github.com/tgstation/tgstation/pull/86574 )

## About The Pull Request

This PR adds a Comprehensive Rules and a Starter Guide on the files of the repo. The idea is that these text files will get a wiki mirror so that you can read them online and in-game, alongside any changes to them automatically updating the manual in-game and on the wiki.

Relevant major rule changes from the current game:
1.2: Decks are 40 cards with a max of 4 cards of the same name rather than 30 cards with 3 of each.
1.8 & 3.6: The player that goes second can gain +1 mana on any turn, once per game. The game didn't had a mechanic to compensate for first player advantage so this is here for that.
**2:** The stack has been entirely removed. Quick/instant effects are still in the game however you cannot use cards in response to another card and before it resolves, only after it resolves. 
**3.4.2:** You can only activate an effect that has a specific trigger if that trigger has happened within the last Closed gamestate and now.

2 and 3.4.2 have a very special interaction that is very important for rulings going forward. Essentially what this does is so that if you have two cards that say "When you draw a card: Deal 1 damage to your opponent" and you draw a card you can only deal 1 damage to your opponent. This is because you draw a card; now the last thing that happened is "you drew a card", and thus you can activate the first card, dealing 1 damage to your opponent. Now the last thing that happened is "you dealt 1 damage to your opponent", meaning you can't use the second card. This has big and widespread implications, specially considering the turn player has priority when activating effects:

- If a creature with "When this destroys an enemy creature:" destroys an enemy creature that says "On Destroyed:" the opponent does not get to use their On Destroyed effect.
- During your turn (and your turn only) you can prevent your opponents' activated effects from happening by using an Instant card right when the opponents' trigger effect would happen.
- If you have multiple cards that trigger at the start of the battle phase you'd have to choose 1 to use and ignore the rest.

Notably, On turn start and On turn end don't suffer from this problem. This is because they can be set to trigger "On the standby phase:" and "On the end phase:" and only check to see if it's the current phase rather than for a specific trigger. This means effects that do should trigger every turn can safely be put in these triggers and not be skipped.

## Why It's Good For The Game
Why it's good to have the new rules: 

Yeah, I'm aware these rules are a bit of a bummer; a lot of triggers will get skipped and lead to a few feels bad moments. However, there are some  very very good reasons why I'm doing this:

- TGC is open source and infinitely expanding as people add new cards. This means that we need a rule system that can handle this expansion with as few rule nightmares as possible. It does increase the learning floor of the game however it also reduces by a very significant amount the level of ruling legalese that you need to know in order to play the game.
- Once you get the gist of the rule it makes it very clear when a trigger can work or not. This is not true for every card game - Yu-Gi-Oh and Magic The Gathering have some very, very janky interactions that are difficult to explain and wrap your head around because of not having a system like this.
- Not letting you use effects in response (only after) the opponent plays a card also prevents many ruling confusions. For example: If I use "Choose a creature; return it to the hand" and my opponent uses "Destroy a creature" in response destroying it before my card effect resolves, does it return it from the discard pile to my hand or does the effect does nothing? Furthermore, if I have a card that says "Give one of your creatures +1/+1 then draw a card" do I still draw if my opponent destroys all my creatures before the effect resolves? By unallowing players to activate effects between paying the mana cost of a card and it resolving, alongside adding a rule that states that in order to activate an effect you must be able to perform all of the effect (and not just parts of the effect) then we completely sidestep all of these issues.
- In sum - it lets us have a much, MUCH easier time later on when we have several different triggers and need to make rules on how to solve complex boardstates and avoid unintuitive rulings besides the first one. It's a speedbump to stop a car crash, essentially.
